### PR TITLE
HUSB238 component fixes/improvements

### DIFF
--- a/esphome/components/husb238/__init__.py
+++ b/esphome/components/husb238/__init__.py
@@ -19,7 +19,7 @@ CONFIG_SCHEMA = cv.Schema(
             cv.GenerateID(): cv.declare_id(Husb238Component),
         }
     )
-    .extend(cv.polling_component_schema("10s"))
+    .extend(cv.polling_component_schema("1s"))
     .extend(i2c.i2c_device_schema(0x08))
 )
 

--- a/esphome/components/husb238/binary_sensor.py
+++ b/esphome/components/husb238/binary_sensor.py
@@ -10,7 +10,7 @@ DEPENDENCIES = ["husb238"]
 CONF_ATTACHED = "attached"
 CONF_CC_DIRECTION = "cc_direction"
 
-TYPES = [CONF_ATTACHED]
+TYPES = [CONF_ATTACHED, CONF_CC_DIRECTION]
 
 CONFIG_SCHEMA = cv.All(
     cv.Schema(

--- a/esphome/components/husb238/husb238.h
+++ b/esphome/components/husb238/husb238.h
@@ -126,7 +126,7 @@ union RegSrcPdoSelect {
     uint8_t reserved : 4;
     SrcVoltageSelection voltage : 4;
   };
-  u_int8_t raw;
+  uint8_t raw;
 };
 
 union RegGoCommand {
@@ -145,10 +145,8 @@ class Husb238Component : public PollingComponent, public i2c::I2CDevice {
   void update() override;
   void dump_config() override;
 
-  bool command_request_voltage(int volt);
   bool command_request_voltage(const std::string &select_state);
   bool command_request_pdo(SrcVoltageSelection voltage);
-  bool command_get_src_cap() { return this->send_command_(CommandFunction::GET_SRC_CAP); };
   bool command_reset() { return this->send_command_(CommandFunction::HARD_RESET); };
 
   bool is_attached();
@@ -192,7 +190,7 @@ class Husb238Component : public PollingComponent, public i2c::I2CDevice {
     uint8_t raw[10];
   } registers_;
 
-  bool read_all_(bool *is_changed);
+  bool read_all_(bool &is_changed);
   bool read_status_();
   bool send_command_(CommandFunction function);
 


### PR DESCRIPTION
* fix voltage/current for non-PD compatible chargers
* fix binary sensors non reporting issue
* reduce I2C request frequency by moving read_all_ from loop() to update()
* send updated values right after new voltage selected
* publish values only if something changed

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
